### PR TITLE
Fix the Category Button Click Error

### DIFF
--- a/app/src/main/java/com/flexcode/yummy/presentation/meals_screen/CategoryItem.kt
+++ b/app/src/main/java/com/flexcode/yummy/presentation/meals_screen/CategoryItem.kt
@@ -56,8 +56,6 @@ fun CategoryItem(
                     .height(100.dp)
                     .fillMaxWidth()
                     .align(Alignment.CenterHorizontally)
-                    .clickable {
-                    }
                     .wrapContentSize(),
             )
 


### PR DESCRIPTION
Noted the Category Item Button was not working when clicked on the upper part as shown on this illustration.

![image](https://user-images.githubusercontent.com/31527935/200227306-043115af-cff3-4c41-bf00-313cee9d6f97.png)

Fixed this by removing the click listener on the image.